### PR TITLE
Fixing foreach warning from undefined variable

### DIFF
--- a/frontend/class-flowplayer5-frontend.php
+++ b/frontend/class-flowplayer5-frontend.php
@@ -41,7 +41,9 @@ class Flowplayer5_Frontend {
 		$this->player_version = $plugin->get_player_version();
 		// Call $plugin_slug from public plugin class.
 		$this->plugin_slug = $plugin->get_plugin_slug();
-
+		// Define an empty array for shortcodes on page
+		$this->has_flowplayer_shortcode = array();
+		
 		// Pull options
 		$options   = get_option( 'fp5_settings_general' );
 		$cdn       = isset( $options['cdn_option'] );


### PR DESCRIPTION
There is currently a 'Warning: Invalid argument supplied for foreach()' on 404 pages as the variable has never been defined, and doesn't get defined if it's a 404 page.