### PR TITLE
Fix bracket misplacement

### DIFF
--- a/frontend/class-flowplayer5-parse.php
+++ b/frontend/class-flowplayer5-parse.php
@@ -211,7 +211,7 @@ class Flowplayer5_Parse {
 		$return['attributes'] = array(
 			( ( $atts['autoplay'] == 'true' ) ? 'autoplay' : '' ),
 			( ( $atts['loop'] == 'true' ) ? 'loop' : '' ),
-			( ! empty ( $atts['preload'] && 'true' !== $atts['live'] ) ? 'preload="' . esc_attr( $atts['preload'] ) . '"' : '' ),
+			( ( ! empty ( $atts['preload'] ) && 'true' !== $atts['live'] ) ? 'preload="' . esc_attr( $atts['preload'] ) . '"' : '' ),
 			( ( $atts['poster'] == 'true' ) ? 'poster' : '' ),
 		);
 


### PR DESCRIPTION
As our Travis builds are failing for the WPSEO Video project I noticed that a bracket was misplaced on the specific line.